### PR TITLE
Implement network bandwidth control in Marathon for Criteo

### DIFF
--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -527,6 +527,11 @@
      "description": "The amount of GPU cores that is needed for the application per instance.",
      "minimum": 0
     },
+    "networkBandwidth": {
+      "type": "integer",
+      "description": "The amount of network bandwidth required for the application per instance.",
+      "minimum": 0
+    },
     "networks": {
       "type": "array",
       "items": {

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -226,6 +226,13 @@ types:
         default: 0
         description: |
           The amount of GPU cores that is needed for the application per instance.
+      networkBandwidth?:
+        type: integer
+        format: int32
+        minimum: 0
+        default: 0
+        description: |
+          The amount of network bandwidth in Mbps that is needed for the application per instance.
       ipAddress?:
         type: network.IpAddress
         (pragma.deprecated): Use `networks` instead.

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -36,6 +36,14 @@ types:
         description: The amount of GPU cores that are needed for the pod
         example: 1
         default: 0
+      networkBandwidth?:
+        displayName: amount of network bandwidth in Mbps
+        type: integer
+        format: int32
+        minimum: 0
+        description: The amount of network bandwidth that is needed for the pod
+        example: 1
+        default: 0
 
   ExecutorResources:
     type: object

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -34,6 +34,7 @@ trait PodsValidation extends GeneralPurposeCombinators {
     resource.mem should be >= 0.0
     resource.disk should be >= 0.0
     resource.gpus should be >= 0
+    resource.networkBandwidth should be >= 0
   }
 
   def httpHealthCheckValidator(endpoints: Seq[Endpoint]) = validator[HttpHealthCheck] { hc =>

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -2,27 +2,27 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.Done
-import akka.actor.{ActorRef, ActorRefFactory}
+import akka.actor.{ ActorRef, ActorRefFactory }
 import akka.event.EventStream
 import akka.pattern.ask
 import akka.stream.Materializer
 import akka.util.Timeout
 import mesosphere.marathon.core.async.ExecutionContexts.global
-import mesosphere.marathon.core.event.{AddHealthCheck, RemoveHealthCheck}
+import mesosphere.marathon.core.event.{ AddHealthCheck, RemoveHealthCheck }
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.health.impl.AppHealthCheckActor.ApplicationKey
-import mesosphere.marathon.core.health.impl.HealthCheckActor.{AppHealth, GetAppHealth, GetInstanceHealth}
+import mesosphere.marathon.core.health.impl.HealthCheckActor.{ AppHealth, GetAppHealth, GetInstanceHealth }
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
+import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.util.RWLock
 import org.apache.mesos.Protos.TaskStatus
 
 import scala.async.Async._
-import scala.collection.immutable.{Map, Seq}
+import scala.collection.immutable.{ Map, Seq }
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -47,7 +47,8 @@ case class PodDefinition(
     cpus = executorResources.cpus + containers.withFilter(filter).map(_.resources.cpus).sum,
     mem = executorResources.mem + containers.withFilter(filter).map(_.resources.mem).sum,
     disk = executorResources.disk + containers.withFilter(filter).map(_.resources.disk).sum,
-    gpus = containers.withFilter(filter).map(_.resources.gpus).sum
+    gpus = containers.withFilter(filter).map(_.resources.gpus).sum,
+    networkBandwidth = containers.withFilter(filter).map(_.resources.networkBandwidth).sum
   )
 
   override def withInstances(instances: Int): RunSpec = copy(instances = instances)

--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -55,6 +55,7 @@ trait AppConversion extends ConstraintConversion with EnvVarConversion with Heal
       executor = app.executor,
       fetch = app.fetch.toRaml,
       gpus = app.resources.gpus,
+      networkBandwidth = app.resources.networkBandwidth,
       healthChecks = app.healthChecks.toRaml,
       instances = app.instances,
       ipAddress = None, // deprecated field
@@ -80,12 +81,13 @@ trait AppConversion extends ConstraintConversion with EnvVarConversion with Heal
     )
   }
 
-  def resources(cpus: Option[Double], mem: Option[Double], disk: Option[Double], gpus: Option[Int]): Resources =
+  def resources(cpus: Option[Double], mem: Option[Double], disk: Option[Double], gpus: Option[Int], networkBandwidth: Option[Int]): Resources =
     Resources(
       cpus = cpus.getOrElse(App.DefaultCpus),
       mem = mem.getOrElse(App.DefaultMem),
       disk = disk.getOrElse(App.DefaultDisk),
-      gpus = gpus.getOrElse(App.DefaultGpus)
+      gpus = gpus.getOrElse(App.DefaultGpus),
+      networkBandwidth = networkBandwidth.getOrElse(App.DefaultNetworkBandwidth)
     )
 
   implicit val taskLostBehaviorReader: Reads[TaskLostBehavior, ResidencyDefinition.TaskLostBehavior] = Reads { taskLost =>
@@ -147,7 +149,7 @@ trait AppConversion extends ConstraintConversion with EnvVarConversion with Heal
       user = app.user,
       env = Raml.fromRaml(app.env),
       instances = app.instances,
-      resources = resources(Some(app.cpus), Some(app.mem), Some(app.disk), Some(app.gpus)),
+      resources = resources(Some(app.cpus), Some(app.mem), Some(app.disk), Some(app.gpus), Some(app.networkBandwidth)),
       executor = app.executor,
       constraints = app.constraints.map(Raml.fromRaml(_))(collection.breakOut),
       fetch = app.fetch.map(Raml.fromRaml(_)),
@@ -188,6 +190,7 @@ trait AppConversion extends ConstraintConversion with EnvVarConversion with Heal
       mem = update.mem.getOrElse(app.mem),
       disk = update.disk.getOrElse(app.disk),
       gpus = update.gpus.getOrElse(app.gpus),
+      networkBandwidth = update.networkBandwidth.getOrElse(app.networkBandwidth),
       executor = update.executor.getOrElse(app.executor),
       constraints = update.constraints.getOrElse(app.constraints),
       fetch = update.fetch.getOrElse(app.fetch),

--- a/src/main/scala/mesosphere/marathon/raml/Apps.scala
+++ b/src/main/scala/mesosphere/marathon/raml/Apps.scala
@@ -19,7 +19,7 @@ trait Apps {
   val DefaultPortDefinitions = Seq(PortDefinition(name = Some("default")))
   val DefaultPortMappings = Seq(ContainerPortMapping(name = Option("default")))
   val DefaultAppResidency = Some(AppResidency())
-  val DefaultResources = Resources(cpus = App.DefaultCpus, mem = App.DefaultMem, disk = App.DefaultDisk, gpus = App.DefaultGpus)
+  val DefaultResources = Resources(cpus = App.DefaultCpus, mem = App.DefaultMem, disk = App.DefaultDisk, gpus = App.DefaultGpus, networkBandwidth = App.DefaultNetworkBandwidth)
 }
 
 object Apps extends Apps

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -70,7 +70,7 @@ trait PodStatusConversion {
 
     val networkStatus: Seq[NetworkStatus] = networkStatuses(instance.tasksMap.values.to[Seq])
     val resources: Resources = containerStatus.flatMap(_.resources).foldLeft(PodDefinition.DefaultExecutorResources) { (all, res) =>
-      all.copy(cpus = all.cpus + res.cpus, mem = all.mem + res.mem, disk = all.disk + res.disk, gpus = all.gpus + res.gpus)
+      all.copy(cpus = all.cpus + res.cpus, mem = all.mem + res.mem, disk = all.disk + res.disk, gpus = all.gpus + res.gpus, networkBandwidth = all.networkBandwidth + res.networkBandwidth)
     }
 
     // TODO(jdef) message, conditions: for example it would probably be nice to see a "healthy" condition here that

--- a/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
+++ b/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
@@ -9,6 +9,7 @@ object NoOfferMatchReason {
   case object InsufficientCpus extends NoOfferMatchReason
   case object InsufficientDisk extends NoOfferMatchReason
   case object InsufficientGpus extends NoOfferMatchReason
+  case object InsufficientNetworkBandwidth extends NoOfferMatchReason
   case object InsufficientPorts extends NoOfferMatchReason
   case object UnfulfilledRole extends NoOfferMatchReason
   case object UnfulfilledConstraint extends NoOfferMatchReason
@@ -27,6 +28,7 @@ object NoOfferMatchReason {
     InsufficientMemory,
     InsufficientDisk,
     InsufficientGpus,
+    InsufficientNetworkBandwidth,
     InsufficientPorts
   )
 
@@ -36,6 +38,7 @@ object NoOfferMatchReason {
     case Resource.GPUS => InsufficientGpus
     case Resource.MEM => InsufficientMemory
     case Resource.PORTS => InsufficientPorts
+    case Resource.NETWORK_BANDWIDTH => InsufficientNetworkBandwidth
     case _ => throw new IllegalArgumentException(s"Not able to match $name to NoOfferMatchReason")
   }
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -153,7 +153,8 @@ object ResourceMatcher extends StrictLogging {
       Seq(
         scalarResourceMatch(Resource.CPUS, runSpec.resources.cpus, ScalarMatchResult.Scope.NoneDisk),
         scalarResourceMatch(Resource.MEM, runSpec.resources.mem, ScalarMatchResult.Scope.NoneDisk),
-        scalarResourceMatch(Resource.GPUS, runSpec.resources.gpus.toDouble, ScalarMatchResult.Scope.NoneDisk)) ++
+        scalarResourceMatch(Resource.GPUS, runSpec.resources.gpus.toDouble, ScalarMatchResult.Scope.NoneDisk),
+        scalarResourceMatch(Resource.NETWORK_BANDWIDTH, runSpec.resources.networkBandwidth.toDouble, ScalarMatchResult.Scope.NoneDisk)) ++
         diskMatch
     ).filter(_.requiredValue != 0)
 

--- a/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
@@ -60,7 +60,7 @@ object RunSpecOfferMatcher extends StrictLogging {
       logger.debug(
         s"Offer [${offer.getId.getValue}]. Insufficient resources for [${runSpec.id}] " +
           s"(need cpus=${runSpec.resources.cpus}, mem=${runSpec.resources.mem}, disk=${runSpec.resources.disk}, " +
-          s"gpus=${runSpec.resources.gpus}, $portsString, available in offer: " +
+          s"gpus=${runSpec.resources.gpus}, $portsString, network_bandwidth=${runSpec.resources.networkBandwidth} available in offer: " +
           s"[${TextFormat.shortDebugString(offer)}]"
       )
     }

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -258,7 +258,8 @@ object TaskBuilder {
         "MARATHON_APP_RESOURCE_CPUS" -> Some(runSpec.resources.cpus.toString),
         "MARATHON_APP_RESOURCE_MEM" -> Some(runSpec.resources.mem.toString),
         "MARATHON_APP_RESOURCE_DISK" -> Some(runSpec.resources.disk.toString),
-        "MARATHON_APP_RESOURCE_GPUS" -> Some(runSpec.resources.gpus.toString)
+        "MARATHON_APP_RESOURCE_GPUS" -> Some(runSpec.resources.gpus.toString),
+        "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH" -> Some(runSpec.resources.networkBandwidth.toString)
       ).collect {
           case (key, Some(value)) => key -> value
         }(collection.breakOut)

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -161,6 +161,7 @@ object TaskGroupBuilder extends StrictLogging {
     builder.addResources(scalarResource("mem", container.resources.mem))
     builder.addResources(scalarResource("disk", container.resources.disk))
     builder.addResources(scalarResource("gpus", container.resources.gpus.toDouble))
+    builder.addResources(scalarResource("network_bandwidth", container.resources.networkBandwidth.toDouble))
 
     if (container.labels.nonEmpty)
       builder.setLabels(mesos.Labels.newBuilder.addAllLabels(container.labels.map {
@@ -214,6 +215,7 @@ object TaskGroupBuilder extends StrictLogging {
     executorInfo.addResources(scalarResource("mem", podDefinition.executorResources.mem))
     executorInfo.addResources(scalarResource("disk", podDefinition.executorResources.disk))
     executorInfo.addResources(scalarResource("gpus", podDefinition.executorResources.gpus.toDouble))
+    executorInfo.addResources(scalarResource("network_bandwidth", podDefinition.executorResources.networkBandwidth.toDouble))
     executorInfo.addAllResources(portsMatch.resources.asJava)
 
     if (podDefinition.networks.nonEmpty || podDefinition.volumes.nonEmpty) {
@@ -467,7 +469,8 @@ object TaskGroupBuilder extends StrictLogging {
       "MARATHON_CONTAINER_RESOURCE_CPUS" -> Some(container.resources.cpus.toString),
       "MARATHON_CONTAINER_RESOURCE_MEM" -> Some(container.resources.mem.toString),
       "MARATHON_CONTAINER_RESOURCE_DISK" -> Some(container.resources.disk.toString),
-      "MARATHON_CONTAINER_RESOURCE_GPUS" -> Some(container.resources.gpus.toString)
+      "MARATHON_CONTAINER_RESOURCE_GPUS" -> Some(container.resources.gpus.toString),
+      "MARATHON_CONTAINER_RESOURCE_NETWORK_BANDWIDTH" -> Some(container.resources.networkBandwidth.toString)
     ).collect {
         case (key, Some(value)) => key -> value
       }

--- a/src/main/scala/mesosphere/mesos/protos/Resource.scala
+++ b/src/main/scala/mesosphere/mesos/protos/Resource.scala
@@ -8,4 +8,5 @@ object Resource {
   final val DISK = "disk"
   final val PORTS = "ports"
   final val GPUS = "gpus"
+  final val NETWORK_BANDWIDTH = "network_bandwidth"
 }

--- a/src/main/scala/mesosphere/mesos/protos/ScalarResource.scala
+++ b/src/main/scala/mesosphere/mesos/protos/ScalarResource.scala
@@ -10,4 +10,5 @@ object ScalarResource {
   def memory(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.MEM, value, role)
   def disk(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.DISK, value, role)
   def gpus(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.GPUS, value, role)
+  def networkBandwidth(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.NETWORK_BANDWIDTH, value, role)
 }

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -820,7 +820,7 @@ class MesosHealthCheckTest extends UnitTest {
 
   def buildIfMatches(app: AppDefinition): Option[(MesosProtos.TaskInfo, NetworkInfo)] = {
     val offer = MarathonTestHelper.makeBasicOfferWithRole(
-      cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved).build
+      cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved).build
 
     val config = MarathonTestHelper.defaultConfig()
     val taskId = Task.Id.forRunSpec(app.id)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActorTest.scala
@@ -4,8 +4,8 @@ package core.health.impl
 import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.event.InstanceHealthChanged
-import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{AddHealthCheck, ApplicationKey, HealthCheckStatusChanged, RemoveHealthCheck}
-import mesosphere.marathon.core.health.{Health, MarathonHttpHealthCheck, PortReference}
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{ AddHealthCheck, ApplicationKey, HealthCheckStatusChanged, RemoveHealthCheck }
+import mesosphere.marathon.core.health.{ Health, MarathonHttpHealthCheck, PortReference }
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp

--- a/src/test/scala/mesosphere/marathon/raml/OfferConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/OfferConversionTest.scala
@@ -75,7 +75,7 @@ class OfferConversionTest extends UnitTest {
       raml.attributes should have size 0
       raml.hostname should be (offer.getHostname)
       raml.id should be (offer.getId.getValue)
-      raml.resources should have size 5
+      raml.resources should have size 6
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
@@ -60,6 +60,7 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("InsufficientMemory", 15, 48), // 48 - 15 = 33
         DeclinedOfferStep("InsufficientDisk", 10, 33), // 33 - 10 = 23
         DeclinedOfferStep("InsufficientGpus", 0, 23),
+        DeclinedOfferStep("InsufficientNetworkBandwidth", 0, 23),
         DeclinedOfferStep("InsufficientPorts", 0, 23)
       )
       val lastOffersSummary: Seq[DeclinedOfferStep] = List(
@@ -70,6 +71,7 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("InsufficientMemory", 1, 1), // 1 - 1 = 0
         DeclinedOfferStep("InsufficientDisk", 0, 0),
         DeclinedOfferStep("InsufficientGpus", 0, 0),
+        DeclinedOfferStep("InsufficientNetworkBandwidth", 0, 0),
         DeclinedOfferStep("InsufficientPorts", 0, 0)
       )
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -77,7 +77,7 @@ object MarathonTestHelper {
   val frameworkID: FrameworkID = FrameworkID("marathon")
   val frameworkId: FrameworkId = FrameworkId("").mergeFromProto(frameworkID)
 
-  def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0,
+  def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0, networkBandwidth: Double = 100000.0,
     beginPort: Int = 31000, endPort: Int = 32000, role: String = ResourceRole.Unreserved,
     reservation: Option[ReservationLabels] = None, gpus: Double = 0.0): Offer.Builder = {
 
@@ -101,6 +101,7 @@ object MarathonTestHelper {
     val gpuResource = heedReserved(ScalarResource(Resource.GPUS, gpus, role = role))
     val memResource = heedReserved(ScalarResource(Resource.MEM, mem, role = role))
     val diskResource = heedReserved(ScalarResource(Resource.DISK, disk, role = role))
+    val networkBandwidthResource = heedReserved(ScalarResource(Resource.NETWORK_BANDWIDTH, networkBandwidth, role = role))
     val portsResource = if (beginPort <= endPort) {
       Some(heedReserved(RangesResource(
         Resource.PORTS,
@@ -119,6 +120,7 @@ object MarathonTestHelper {
       .addResources(gpuResource)
       .addResources(memResource)
       .addResources(diskResource)
+      .addResources(networkBandwidthResource)
 
     portsResource.foreach(offerBuilder.addResources)
 
@@ -271,7 +273,7 @@ object MarathonTestHelper {
     offerBuilder
   }
 
-  def makeBasicOfferWithRole(cpus: Double, mem: Double, disk: Double,
+  def makeBasicOfferWithRole(cpus: Double, mem: Double, disk: Double, networkBandwidth: Double,
     beginPort: Int, endPort: Int, role: String) = {
     val portsResource = RangesResource(
       Resource.PORTS,
@@ -281,6 +283,7 @@ object MarathonTestHelper {
     val cpusResource = ScalarResource(Resource.CPUS, cpus, role)
     val memResource = ScalarResource(Resource.MEM, mem, role)
     val diskResource = ScalarResource(Resource.DISK, disk, role)
+    val networkBandwidthResource = ScalarResource(Resource.NETWORK_BANDWIDTH, networkBandwidth, role)
     Offer.newBuilder
       .setId(OfferID("1"))
       .setFrameworkId(frameworkID)

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -5,19 +5,19 @@ import java.time.{ OffsetDateTime, ZoneOffset }
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{App, Resources}
-import mesosphere.marathon.state.Container.{Docker, PortMapping}
+import mesosphere.marathon.raml.{ App, Resources }
+import mesosphere.marathon.state.Container.{ Docker, PortMapping }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
+import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.MarathonTestHelper
-import mesosphere.marathon.{Protos, _}
-import mesosphere.mesos.protos.{Resource, _}
+import mesosphere.marathon.{ Protos, _ }
+import mesosphere.mesos.protos.{ Resource, _ }
 import org.apache.mesos.Protos.TaskInfo
 import org.apache.mesos.{ Protos => MesosProtos }
 

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -33,14 +33,14 @@ class TaskBuilderTest extends UnitTest {
 
   "TaskBuilder" should {
     "BuildIfMatches" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.0, mem = 128.0, disk = 2000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000).build
 
       val task: Option[(MesosProtos.TaskInfo, NetworkInfo)] = buildIfMatches(
         offer,
         AppDefinition(
           id = "/product/frontend".toPath,
           cmd = Some("foo"),
-          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
+          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0, networkBandwidth = 100),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         )
@@ -320,14 +320,14 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "build creates task with appropriate resource share" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 2.0, mem = 128.0, disk = 2000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000).build
 
       val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
         offer,
         AppDefinition(
           id = "/product/frontend".toPath,
           cmd = Some("foo"),
-          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
+          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0, networkBandwidth = 100),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         )
@@ -340,6 +340,7 @@ class TaskBuilderTest extends UnitTest {
       assert(resource("cpus") == ScalarResource("cpus", 1))
       assert(resource("mem") == ScalarResource("mem", 64))
       assert(resource("disk") == ScalarResource("disk", 1))
+      assert(resource("network_bandwidth") == ScalarResource("network_bandwidth", 100))
       val portsResource: Resource = resource("ports")
       assert(portsResource.getRanges.getRangeList.map(range => range.getEnd - range.getBegin + 1).sum == 2)
       assert(portsResource.getRole == ResourceRole.Unreserved)
@@ -367,7 +368,7 @@ class TaskBuilderTest extends UnitTest {
 
     "build creates task with appropriate resource share also preserves role" in {
       val offer = MarathonTestHelper.makeBasicOffer(
-        cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000, role = "marathon"
+        cpus = 2.0, mem = 128.0, disk = 2000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon"
       ).build
 
       val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
@@ -375,7 +376,7 @@ class TaskBuilderTest extends UnitTest {
         AppDefinition(
           id = "/product/frontend".toPath,
           cmd = Some("foo"),
-          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
+          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0, networkBandwidth = 100),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         ),
@@ -390,6 +391,7 @@ class TaskBuilderTest extends UnitTest {
       assert(resource("cpus") == ScalarResource("cpus", 1, "marathon"))
       assert(resource("mem") == ScalarResource("mem", 64, "marathon"))
       assert(resource("disk") == ScalarResource("disk", 1, "marathon"))
+      assert(resource("network_bandwidth") == ScalarResource("network_bandwidth", 100, "marathon"))
       val portsResource: Resource = resource("ports")
       assert(portsResource.getRanges.getRangeList.map(range => range.getEnd - range.getBegin + 1).sum == 2)
       assert(portsResource.getRole == "marathon")
@@ -626,7 +628,7 @@ class TaskBuilderTest extends UnitTest {
 
     "build creates task for MESOS Docker container" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -668,7 +670,7 @@ class TaskBuilderTest extends UnitTest {
 
     "build creates task for MESOS AppC container" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -994,13 +996,15 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "BuildIfMatchesWithRole" in {
-      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon")
+      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon")
         .addResources(ScalarResource("cpus", 1, ResourceRole.Unreserved))
         .addResources(ScalarResource("mem", 128, ResourceRole.Unreserved))
         .addResources(ScalarResource("disk", 1000, ResourceRole.Unreserved))
+        .addResources(ScalarResource("network_bandwidth", 400, ResourceRole.Unreserved))
         .addResources(ScalarResource("cpus", 2, "marathon"))
         .addResources(ScalarResource("mem", 256, "marathon"))
         .addResources(ScalarResource("disk", 2000, "marathon"))
+        .addResources(ScalarResource("network_bandwidth", 600, "marathon"))
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
 
@@ -1008,7 +1012,7 @@ class TaskBuilderTest extends UnitTest {
         offer,
         AppDefinition(
           id = "/testApp".toPath,
-          resources = Resources(cpus = 2.0, mem = 200.0, disk = 2.0),
+          resources = Resources(cpus = 2.0, mem = 200.0, disk = 2.0, networkBandwidth = 600),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         ),
@@ -1033,13 +1037,15 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "BuildIfMatchesWithRole2" in {
-      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved)
+      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved)
         .addResources(ScalarResource("cpus", 1, ResourceRole.Unreserved))
         .addResources(ScalarResource("mem", 128, ResourceRole.Unreserved))
         .addResources(ScalarResource("disk", 1000, ResourceRole.Unreserved))
+        .addResources(ScalarResource("network_bandwidth", 400, ResourceRole.Unreserved))
         .addResources(ScalarResource("cpus", 2, "marathon"))
         .addResources(ScalarResource("mem", 256, "marathon"))
         .addResources(ScalarResource("disk", 2000, "marathon"))
+        .addResources(ScalarResource("network_bandwidth", 600))
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
 
@@ -1072,7 +1078,7 @@ class TaskBuilderTest extends UnitTest {
 
     "PortMappingsWithZeroContainerPort" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31000, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31000, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1100,7 +1106,7 @@ class TaskBuilderTest extends UnitTest {
 
     "PortMappingsWithUserModeAndDefaultPortMapping" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1132,7 +1138,7 @@ class TaskBuilderTest extends UnitTest {
 
     "Docker Container PortMappingsWithoutHostPort" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1167,7 +1173,7 @@ class TaskBuilderTest extends UnitTest {
 
     "Mesos Container PortMappingsWithoutHostPort" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1206,7 +1212,7 @@ class TaskBuilderTest extends UnitTest {
 
     "DockerContainerWithMesosTaskIdLabel" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1399,6 +1405,7 @@ class TaskBuilderTest extends UnitTest {
           "MARATHON_APP_RESOURCE_MEM" -> App.DefaultMem.toString,
           "MARATHON_APP_RESOURCE_DISK" -> App.DefaultDisk.toString,
           "MARATHON_APP_RESOURCE_GPUS" -> App.DefaultGpus.toString,
+          "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH" -> App.DefaultNetworkBandwidth.toString,
           "MARATHON_APP_LABELS" -> ""
         )
       )
@@ -1413,7 +1420,7 @@ class TaskBuilderTest extends UnitTest {
         container = Some(Docker(
           image = "myregistry/myimage:version"
         )),
-        resources = Resources(cpus = 10.0, mem = 256.0, disk = 128.0, gpus = 2),
+        resources = Resources(cpus = 10.0, mem = 256.0, disk = 128.0, gpus = 2, networkBandwidth = 1024),
         labels = Map(
           "LABEL1" -> "VALUE1",
           "LABEL2" -> "VALUE2"
@@ -1432,6 +1439,7 @@ class TaskBuilderTest extends UnitTest {
           "MARATHON_APP_RESOURCE_MEM" -> "256.0",
           "MARATHON_APP_RESOURCE_DISK" -> "128.0",
           "MARATHON_APP_RESOURCE_GPUS" -> "2",
+          "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH" -> "1024",
           "MARATHON_APP_LABELS" -> "LABEL1 LABEL2",
           "MARATHON_APP_LABEL_LABEL1" -> "VALUE1",
           "MARATHON_APP_LABEL_LABEL2" -> "VALUE2"
@@ -1596,7 +1604,7 @@ class TaskBuilderTest extends UnitTest {
       val nonPrefixedEnvVars = env.filterKeys(!_.startsWith("P_"))
 
       val whiteList = Seq("MESOS_TASK_ID", "MARATHON_APP_ID", "MARATHON_APP_VERSION", "MARATHON_APP_RESOURCE_CPUS",
-        "MARATHON_APP_RESOURCE_MEM", "MARATHON_APP_RESOURCE_DISK", "MARATHON_APP_RESOURCE_GPUS", "MARATHON_APP_LABELS")
+        "MARATHON_APP_RESOURCE_MEM", "MARATHON_APP_RESOURCE_DISK", "MARATHON_APP_RESOURCE_GPUS", "MARATHON_APP_LABELS", "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH")
 
       assert(nonPrefixedEnvVars.keySet.forall(whiteList.contains))
     }

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -62,7 +62,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
     }
 
     "build from a PodDefinition with a single container" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0, disk = 10.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0, disk = 10.0, networkBandwidth = 100.0).build
 
       val podSpec = PodDefinition(
         id = "/product/frontend".toPath,
@@ -70,7 +70,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
           MesosContainer(
             name = "Foo",
             exec = None,
-            resources = raml.Resources(cpus = 1.0f, mem = 128.0f)
+            resources = raml.Resources(cpus = 1.0f, mem = 128.0f, networkBandwidth = 100)
           )
         )
       )
@@ -88,22 +88,22 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
     }
 
     "build from a PodDefinition with multiple containers" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0, networkBandwidth = 400.0).build
 
       val podSpec = PodDefinition(
         id = "/product/frontend".toPath,
         containers = Seq(
           MesosContainer(
             name = "Foo",
-            resources = raml.Resources(cpus = 1.0f, mem = 512.0f)
+            resources = raml.Resources(cpus = 1.0f, mem = 512.0f, networkBandwidth = 100)
           ),
           MesosContainer(
             name = "Foo2",
-            resources = raml.Resources(cpus = 2.0f, mem = 256.0f)
+            resources = raml.Resources(cpus = 2.0f, mem = 256.0f, networkBandwidth = 100)
           ),
           MesosContainer(
             name = "Foo3",
-            resources = raml.Resources(cpus = 1.0f, mem = 256.0f)
+            resources = raml.Resources(cpus = 1.0f, mem = 256.0f, networkBandwidth = 100)
           )
         )
       )
@@ -282,7 +282,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.0f, mem = 1024.0f, disk = 10.0).build()
       val mesosContainer = MesosContainer(
         name = containerIdStr,
-        resources = raml.Resources(cpus = 2.0f, mem = 512.0f, disk = 0.0f)
+        resources = raml.Resources(cpus = 2.0f, mem = 512.0f, disk = 0.0f, networkBandwidth = 100)
       )
 
       val podSpec = PodDefinition(


### PR DESCRIPTION
As there is no support of custom resources in Marathon yet, we implement networkBandwidth as a standard resource like GPU until custom resources become available in Marathon.