### PR TITLE
Make sure networkBandwidth can be specified in all scenarii

### DIFF
--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -333,6 +333,7 @@ trait AppConversion extends ConstraintConversion with EnvVarConversion with Heal
       maxLaunchDelaySeconds = service.whenOrElse(_.hasMaxLaunchDelay, m => (m.getMaxLaunchDelay / 1000L).toInt, App.DefaultMaxLaunchDelaySeconds),
       mem = resourcesMap.getOrElse(Resource.MEM, App.DefaultMem),
       gpus = resourcesMap.get(Resource.GPUS).fold(App.DefaultGpus)(_.toInt),
+      networkBandwidth = resourcesMap.get(Resource.NETWORK_BANDWIDTH).fold(App.DefaultNetworkBandwidth)(_.toInt),
       ipAddress = service.when(_.hasOBSOLETEIpAddress, _.getOBSOLETEIpAddress.toRaml).orElse(App.DefaultIpAddress),
       networks = service.whenOrElse(_.getNetworksCount > 0, _.getNetworksList.toRaml, App.DefaultNetworks),
       ports = None, // not stored in protobuf
@@ -384,6 +385,7 @@ trait AppConversion extends ConstraintConversion with EnvVarConversion with Heal
       mem = Some(app.mem),
       disk = Some(app.disk),
       gpus = Some(app.gpus),
+      networkBandwidth = Some(app.networkBandwidth),
       executor = Some(app.executor),
       constraints = Some(app.constraints),
       fetch = Some(app.fetch),

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -138,6 +138,7 @@ case class AppDefinition(
     val memResource = ScalarResource(Resource.MEM, resources.mem)
     val diskResource = ScalarResource(Resource.DISK, resources.disk)
     val gpusResource = ScalarResource(Resource.GPUS, resources.gpus.toDouble)
+    val networkBandwidthResource = ScalarResource(Resource.NETWORK_BANDWIDTH, resources.networkBandwidth.toDouble)
     val appLabels = labels.map {
       case (key, value) =>
         mesos.Parameter.newBuilder
@@ -161,6 +162,7 @@ case class AppDefinition(
       .addResources(memResource)
       .addResources(diskResource)
       .addResources(gpusResource)
+      .addResources(networkBandwidthResource)
       .addAllHealthChecks(healthChecks.map(_.toProto).asJava)
       .setUpgradeStrategy(upgradeStrategy.toProto)
       .addAllDependencies(dependencies.map(_.toString).asJava)
@@ -262,7 +264,8 @@ case class AppDefinition(
         cpus = resourcesMap.getOrElse(Resource.CPUS, this.resources.cpus),
         mem = resourcesMap.getOrElse(Resource.MEM, this.resources.mem),
         disk = resourcesMap.getOrElse(Resource.DISK, this.resources.disk),
-        gpus = resourcesMap.getOrElse(Resource.GPUS, this.resources.gpus.toDouble).toInt
+        gpus = resourcesMap.getOrElse(Resource.GPUS, this.resources.gpus.toDouble).toInt,
+        networkBandwidth = resourcesMap.getOrElse(Resource.NETWORK_BANDWIDTH, this.resources.networkBandwidth.toDouble).toInt
       ),
       env = envMap ++ envRefs,
       fetch = proto.getCmd.getUrisList.map(FetchUri.fromProto)(collection.breakOut),
@@ -559,6 +562,7 @@ object AppDefinition extends GeneralPurposeCombinators {
     appDef.instances should be >= 0
     appDef.resources.disk as "disk" should be >= 0.0
     appDef.resources.gpus as "gpus" should be >= 0
+    appDef.resources.networkBandwidth as "networkBandwidth" should be >= 0
     appDef.secrets is valid(Secret.secretsValidator)
     appDef.secrets is empty or featureEnabled(enabledFeatures, Features.SECRETS)
     appDef.env is valid(EnvVarValue.envValidator)
@@ -606,6 +610,7 @@ object AppDefinition extends GeneralPurposeCombinators {
           from.resources.mem == to.resources.mem &&
           from.resources.disk == to.resources.disk &&
           from.resources.gpus == to.resources.gpus &&
+          from.resources.networkBandwidth == to.resources.networkBandwidth &&
           from.hostPorts.flatten.toSet == to.hostPorts.flatten.toSet &&
           from.requirePorts == to.requirePorts
       }


### PR DESCRIPTION
Before this patch:
- updates with `partialUpdate: true` allow networkBandwidth to be
changed
- updates with `partialUpdate: false` (or without any mention of it)
  ignore the networkBandwidth field
- app creation properly treated networkBandwidth field

After this patch, all of those scenarios works correctly.

I'm not yet able to write a test for the faulty scenario. It may come
later

Change-Id: I2120a82a03bacd581836ed116911aa3f17ec2f41