### PR TITLE
Add implementation of bandwidth control to marathon 1.6.549

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,36 @@
+# any change to this file upstream will conflict when we merge changes
+# deploy section has to remain intact but the rest can be resolved using upstream version
 sudo: false
 language: scala
 jdk:
-  - oraclejdk8
+- oraclejdk8
 scala:
   - 2.12.3
 cache:
   directories:
-    - $HOME/.sbt
-    - $HOME/.ivy2
+  - "$HOME/.sbt"
+  - "$HOME/.ivy2"
 script:
-  - sbt clean scapegoat doc coverage test
+- sbt "set parallelExecution in Test := false" clean coverage doc package
 before_script: # the automated download fails sometimes
-    - mkdir -p $HOME/.sbt/launchers/0.13.11/
-    - test -r $HOME/.sbt/launchers/0.13.11/sbt-launch.jar || curl -L -o $HOME/.sbt/launchers/0.13.11/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.11/sbt-launch.jar
+- mkdir -p $HOME/.sbt/launchers/0.13.11/
+- test -r $HOME/.sbt/launchers/0.13.11/sbt-launch.jar || curl -L -o $HOME/.sbt/launchers/0.13.11/sbt-launch.jar
+  http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.11/sbt-launch.jar
+- ./patch_version.sh
 after_success:
-  - sbt coverageReport coveralls
-notifications:
-  slack:
-    secure: apUObVUa/OhaTEvoYw3oM1ZTTT0LtYolofJYqnWiBOusc6qgMlK2rfk5kod7vDn33cSKwGhFcyVrrFCn2qxuvYUWCpK4Yo6Hj7KIjoqMi9yHLHXAAWIfAFNMlCdaUGjlHLWn757rBkbuQUDVH8HmB6Vc3J3sybTbiFmMDP1cEVo=
+- sbt coverageReport coveralls
+before_deploy:
+  - export RELEASE_JAR_FILE=$(ls target/scala*/marathon-*.jar)
+  - export VERSION=$(echo $TRAVIS_TAG | sed 's/^v//' )
+  - echo "deploying $RELEASE_PKG_FILE to GitHub releases"
+  - tar czvf marathon-$VERSION.tgz $RELEASE_JAR_FILE
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: geOsznYimDVjY54rYF5K205bjt+Q/vZRa7trLq8IKSxf/NiZb4ZiQzPcFfQ4328nA++7+NSW697YwpdJiB4M+21FEcpsB4kLPqrqr92o8u12Zgn5wOJUmNi1wrJyKjO5pScB6qf7Ev8hvpXCvAVRK7tltRfLT2xYQ+JGXYuiForHd4yMbK6WFOvi0zjkUjqosdffAb9SqbmKmI2K0VGP/5q90ZfShmEAk4WYth+dECloVhvBksqcRympL5VijM2cq4MrY/NMDznyX9VvmpQiae+Q1A4fhrUfPTPVmDJStZlIVXwIFNFVZJdXeUZOyafKMOaCU5XB9LFrkX2NlaGjEtWYSBP3uGm0/uApzNCTJ2OodT5WMqeuQTCLbmQbfOfstyeCx/g+YzmVhgK5EiWWPLrfIzucj2P2uEtt0mBlMiw4Ts+Maw5ehMVb+pEMHDVAneMyZw8zyd3EvG6RLnO05kgLmy5gS7ozHhyPFG57xcclKzZ9eV8rHbiCxPrvuAyCwfdM3hp9/A10u+CkQCr43KIPrcTsREbMAkcdmHh5jM0AGw5zcUlGSIZNDQ/soNfLqaBAESpvFW4c4Ak7CIr8HxV1imiBgn3PnwHeWTz4wlcAflxPb7DGbCReyMIOfW+RNzIpCorxfXi5xg29Q7OSRH+rGA3vtcA4IwY8vAPsriU=
+  file_glob: true
+  file: "marathon-$VERSION.tgz"
+  on:
+    repo: criteo-forks/marathon
+    tags: true

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -555,6 +555,11 @@
      "description": "The amount of GPU cores that is needed for the application per instance.",
      "minimum": 0
     },
+    "networkBandwidth": {
+      "type": "integer",
+      "description": "The amount of network bandwidth required for the application per instance.",
+      "minimum": 0
+    },
     "networks": {
       "type": "array",
       "items": {

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -233,6 +233,13 @@ types:
         default: 0
         description: |
           The amount of GPU cores that is needed for the application per instance.
+      networkBandwidth?:
+        type: integer
+        format: int32
+        minimum: 0
+        default: 0
+        description: |
+          The amount of network bandwidth in Mbps that is needed for the application per instance.
       ipAddress?:
         type: network.IpAddress
         (pragma.deprecated): Use `networks` instead.

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -36,6 +36,14 @@ types:
         description: The amount of GPU cores that are needed for the pod
         example: 1
         default: 0
+      networkBandwidth?:
+        displayName: amount of network bandwidth in Mbps
+        type: integer
+        format: int32
+        minimum: 0
+        description: The amount of network bandwidth that is needed for the pod
+        example: 1
+        default: 0
 
   ExecutorResources:
     type: object

--- a/patch_version.sh
+++ b/patch_version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# this script will patch version.sbt to put the right version if we are building a tag
+
+if [[ ! -z "$TRAVIS_TAG" ]]; then
+  echo "version in ThisBuild := \"$TRAVIS_TAG\"" > version.sbt
+fi

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -33,6 +33,7 @@ trait PodsValidation extends GeneralPurposeCombinators {
     resource.mem should be >= 0.0
     resource.disk should be >= 0.0
     resource.gpus should be >= 0
+    resource.networkBandwidth should be >= 0
   }
 
   def httpHealthCheckValidator(endpoints: Seq[Endpoint]) = validator[HttpHealthCheck] { hc =>

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.Done
-import akka.actor.{ ActorRef, ActorRefFactory }
+import akka.actor.{ActorRef, ActorRefFactory}
 import akka.event.EventStream
 import akka.pattern.ask
 import akka.stream.Materializer
@@ -11,21 +11,20 @@ import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.event.{AddHealthCheck, RemoveHealthCheck}
-import mesosphere.marathon.core.async.ExecutionContexts.global
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.health.impl.AppHealthCheckActor.ApplicationKey
-import mesosphere.marathon.core.health.impl.HealthCheckActor.{ AppHealth, GetAppHealth, GetInstanceHealth }
+import mesosphere.marathon.core.health.impl.HealthCheckActor.{AppHealth, GetAppHealth, GetInstanceHealth}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import mesosphere.util.RWLock
 import org.apache.mesos.Protos.TaskStatus
 
 import scala.async.Async._
-import scala.collection.immutable.{ Map, Seq }
+import scala.collection.immutable.{Map, Seq}
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.Done
-import akka.actor.{ActorRef, ActorRefFactory}
+import akka.actor.{ ActorRef, ActorRefFactory }
 import akka.event.EventStream
 import akka.pattern.ask
 import akka.stream.Materializer
@@ -11,20 +11,21 @@ import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.event.{AddHealthCheck, RemoveHealthCheck}
+import mesosphere.marathon.core.async.ExecutionContexts.global
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.health.impl.AppHealthCheckActor.ApplicationKey
-import mesosphere.marathon.core.health.impl.HealthCheckActor.{AppHealth, GetAppHealth, GetInstanceHealth}
+import mesosphere.marathon.core.health.impl.HealthCheckActor.{ AppHealth, GetAppHealth, GetInstanceHealth }
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
+import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.util.RWLock
 import org.apache.mesos.Protos.TaskStatus
 
 import scala.async.Async._
-import scala.collection.immutable.{Map, Seq}
+import scala.collection.immutable.{ Map, Seq }
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -57,7 +57,8 @@ case class PodDefinition(
     cpus = executorResources.cpus + containers.withFilter(filter).map(_.resources.cpus).sum,
     mem = executorResources.mem + containers.withFilter(filter).map(_.resources.mem).sum,
     disk = executorResources.disk + containers.withFilter(filter).map(_.resources.disk).sum,
-    gpus = containers.withFilter(filter).map(_.resources.gpus).sum
+    gpus = containers.withFilter(filter).map(_.resources.gpus).sum,
+    networkBandwidth = containers.withFilter(filter).map(_.resources.networkBandwidth).sum
   )
 
   override def withInstances(instances: Int): RunSpec = copy(instances = instances)

--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -50,6 +50,7 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
       executor = app.executor,
       fetch = app.fetch.toRaml,
       gpus = app.resources.gpus,
+      networkBandwidth = app.resources.networkBandwidth,
       healthChecks = app.healthChecks.toRaml,
       instances = app.instances,
       ipAddress = None, // deprecated field
@@ -84,12 +85,13 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
     )
   }
 
-  def resources(cpus: Option[Double], mem: Option[Double], disk: Option[Double], gpus: Option[Int]): Resources =
+  def resources(cpus: Option[Double], mem: Option[Double], disk: Option[Double], gpus: Option[Int], networkBandwidth: Option[Int]): Resources =
     Resources(
       cpus = cpus.getOrElse(App.DefaultCpus),
       mem = mem.getOrElse(App.DefaultMem),
       disk = disk.getOrElse(App.DefaultDisk),
-      gpus = gpus.getOrElse(App.DefaultGpus)
+      gpus = gpus.getOrElse(App.DefaultGpus),
+      networkBandwidth = networkBandwidth.getOrElse(App.DefaultNetworkBandwidth)
     )
 
   implicit val taskLostBehaviorReader: Reads[TaskLostBehavior, ResidencyDefinition.TaskLostBehavior] = Reads { taskLost =>
@@ -143,7 +145,7 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
       user = app.user,
       env = Raml.fromRaml(app.env),
       instances = app.instances,
-      resources = resources(Some(app.cpus), Some(app.mem), Some(app.disk), Some(app.gpus)),
+      resources = resources(Some(app.cpus), Some(app.mem), Some(app.disk), Some(app.gpus), Some(app.networkBandwidth)),
       executor = app.executor,
       constraints = app.constraints.map(Raml.fromRaml(_))(collection.breakOut),
       fetch = app.fetch.map(Raml.fromRaml(_)),
@@ -184,6 +186,7 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
       mem = update.mem.getOrElse(app.mem),
       disk = update.disk.getOrElse(app.disk),
       gpus = update.gpus.getOrElse(app.gpus),
+      networkBandwidth = update.networkBandwidth.getOrElse(app.networkBandwidth),
       executor = update.executor.getOrElse(app.executor),
       constraints = update.constraints.getOrElse(app.constraints),
       fetch = update.fetch.getOrElse(app.fetch),

--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -344,6 +344,7 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
       maxLaunchDelaySeconds = service.whenOrElse(_.hasMaxLaunchDelay, m => (m.getMaxLaunchDelay / 1000L).toInt, App.DefaultMaxLaunchDelaySeconds),
       mem = resourcesMap.getOrElse(Resource.MEM, App.DefaultMem),
       gpus = resourcesMap.get(Resource.GPUS).fold(App.DefaultGpus)(_.toInt),
+      networkBandwidth = resourcesMap.get(Resource.NETWORK_BANDWIDTH).fold(App.DefaultNetworkBandwidth)(_.toInt),
       ipAddress = service.when(_.hasOBSOLETEIpAddress, _.getOBSOLETEIpAddress.toRaml).orElse(App.DefaultIpAddress),
       networks = service.whenOrElse(_.getNetworksCount > 0, _.getNetworksList.toRaml, App.DefaultNetworks),
       ports = None, // not stored in protobuf
@@ -395,6 +396,7 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
       mem = Some(app.mem),
       disk = Some(app.disk),
       gpus = Some(app.gpus),
+      networkBandwidth = Some(app.networkBandwidth),
       executor = Some(app.executor),
       constraints = Some(app.constraints),
       fetch = Some(app.fetch),

--- a/src/main/scala/mesosphere/marathon/raml/Apps.scala
+++ b/src/main/scala/mesosphere/marathon/raml/Apps.scala
@@ -19,7 +19,7 @@ trait Apps {
   val DefaultPortDefinitions = Seq(PortDefinition(name = Some("default")))
   val DefaultPortMappings = Seq(ContainerPortMapping(name = Option("default")))
   val DefaultAppResidency = Some(AppResidency())
-  val DefaultResources = Resources(cpus = App.DefaultCpus, mem = App.DefaultMem, disk = App.DefaultDisk, gpus = App.DefaultGpus)
+  val DefaultResources = Resources(cpus = App.DefaultCpus, mem = App.DefaultMem, disk = App.DefaultDisk, gpus = App.DefaultGpus, networkBandwidth = App.DefaultNetworkBandwidth)
 }
 
 object Apps extends Apps

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -75,7 +75,7 @@ trait PodStatusConversion {
 
     val networkStatus: Seq[NetworkStatus] = networkStatuses(instance.tasksMap.values.to[Seq])
     val resources: Resources = containerStatus.flatMap(_.resources).foldLeft(PodDefinition.DefaultExecutorResources) { (all, res) =>
-      all.copy(cpus = all.cpus + res.cpus, mem = all.mem + res.mem, disk = all.disk + res.disk, gpus = all.gpus + res.gpus)
+      all.copy(cpus = all.cpus + res.cpus, mem = all.mem + res.mem, disk = all.disk + res.disk, gpus = all.gpus + res.gpus, networkBandwidth = all.networkBandwidth + res.networkBandwidth)
     }
 
     val localVolumes = instance.reservation.fold(Seq.empty[LocalVolumeId]) { reservation =>

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -150,6 +150,7 @@ case class AppDefinition(
     val memResource = ScalarResource(Resource.MEM, resources.mem)
     val diskResource = ScalarResource(Resource.DISK, resources.disk)
     val gpusResource = ScalarResource(Resource.GPUS, resources.gpus.toDouble)
+    val networkBandwidthResource = ScalarResource(Resource.NETWORK_BANDWIDTH, resources.networkBandwidth.toDouble)
     val appLabels = labels.map {
       case (key, value) =>
         mesos.Parameter.newBuilder
@@ -173,6 +174,7 @@ case class AppDefinition(
       .addResources(memResource)
       .addResources(diskResource)
       .addResources(gpusResource)
+      .addResources(networkBandwidthResource)
       .addAllHealthChecks(healthChecks.map(_.toProto).asJava)
       .setUpgradeStrategy(upgradeStrategy.toProto)
       .addAllDependencies(dependencies.map(_.toString).asJava)
@@ -293,7 +295,8 @@ case class AppDefinition(
         cpus = resourcesMap.getOrElse(Resource.CPUS, this.resources.cpus),
         mem = resourcesMap.getOrElse(Resource.MEM, this.resources.mem),
         disk = resourcesMap.getOrElse(Resource.DISK, this.resources.disk),
-        gpus = resourcesMap.getOrElse(Resource.GPUS, this.resources.gpus.toDouble).toInt
+        gpus = resourcesMap.getOrElse(Resource.GPUS, this.resources.gpus.toDouble).toInt,
+        networkBandwidth = resourcesMap.getOrElse(Resource.NETWORK_BANDWIDTH, this.resources.networkBandwidth.toDouble).toInt
       ),
       env = envMap ++ envRefs,
       fetch = proto.getCmd.getUrisList.map(FetchUri.fromProto)(collection.breakOut),
@@ -574,6 +577,7 @@ object AppDefinition extends GeneralPurposeCombinators {
     appDef.instances should be >= 0
     appDef.resources.disk as "disk" should be >= 0.0
     appDef.resources.gpus as "gpus" should be >= 0
+    appDef.resources.networkBandwidth as "networkBandwidth" should be >= 0
     appDef.secrets is valid(Secret.secretsValidator)
     appDef.secrets is empty or featureEnabled(enabledFeatures, Features.SECRETS)
     appDef.env is valid(EnvVarValue.envValidator)
@@ -620,6 +624,7 @@ object AppDefinition extends GeneralPurposeCombinators {
           from.resources.mem == to.resources.mem &&
           from.resources.disk == to.resources.disk &&
           from.resources.gpus == to.resources.gpus &&
+          from.resources.networkBandwidth == to.resources.networkBandwidth &&
           from.hostPorts.flatten.toSet == to.hostPorts.flatten.toSet &&
           from.requirePorts == to.requirePorts
       }

--- a/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
+++ b/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
@@ -9,6 +9,7 @@ object NoOfferMatchReason {
   case object InsufficientCpus extends NoOfferMatchReason
   case object InsufficientDisk extends NoOfferMatchReason
   case object InsufficientGpus extends NoOfferMatchReason
+  case object InsufficientNetworkBandwidth extends NoOfferMatchReason
   case object InsufficientPorts extends NoOfferMatchReason
   case object UnfulfilledRole extends NoOfferMatchReason
   case object UnfulfilledConstraint extends NoOfferMatchReason
@@ -31,6 +32,7 @@ object NoOfferMatchReason {
     InsufficientDisk,
     InsufficientGpus,
     InsufficientPorts,
+    InsufficientNetworkBandwidth,
     DeclinedScarceResources
   )
 
@@ -40,6 +42,7 @@ object NoOfferMatchReason {
     case Resource.GPUS => InsufficientGpus
     case Resource.MEM => InsufficientMemory
     case Resource.PORTS => InsufficientPorts
+    case Resource.NETWORK_BANDWIDTH => InsufficientNetworkBandwidth
     case _ => throw new IllegalArgumentException(s"Not able to match $name to NoOfferMatchReason")
   }
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -180,7 +180,8 @@ object ResourceMatcher extends StrictLogging {
       Seq(
         scalarResourceMatch(Resource.CPUS, runSpec.resources.cpus, ScalarMatchResult.Scope.NoneDisk),
         scalarResourceMatch(Resource.MEM, runSpec.resources.mem, ScalarMatchResult.Scope.NoneDisk),
-        scalarResourceMatch(Resource.GPUS, runSpec.resources.gpus.toDouble, ScalarMatchResult.Scope.NoneDisk)) ++
+        scalarResourceMatch(Resource.GPUS, runSpec.resources.gpus.toDouble, ScalarMatchResult.Scope.NoneDisk),
+        scalarResourceMatch(Resource.NETWORK_BANDWIDTH, runSpec.resources.networkBandwidth.toDouble, ScalarMatchResult.Scope.NoneDisk)) ++
         diskMatch
     ).filter(_.requiredValue != 0)
 

--- a/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
@@ -64,7 +64,7 @@ object RunSpecOfferMatcher extends StrictLogging {
       logger.debug(
         s"Offer [${offer.getId.getValue}]. Insufficient resources for [${runSpec.id}] " +
           s"(need cpus=${runSpec.resources.cpus}, mem=${runSpec.resources.mem}, disk=${runSpec.resources.disk}, " +
-          s"gpus=${runSpec.resources.gpus}, $portsString, available in offer: " +
+          s"gpus=${runSpec.resources.gpus}, $portsString, network_bandwidth=${runSpec.resources.networkBandwidth} available in offer: " +
           s"[${TextFormat.shortDebugString(offer)}]"
       )
     }

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -271,7 +271,8 @@ object TaskBuilder {
         "MARATHON_APP_RESOURCE_CPUS" -> Some(runSpec.resources.cpus.toString),
         "MARATHON_APP_RESOURCE_MEM" -> Some(runSpec.resources.mem.toString),
         "MARATHON_APP_RESOURCE_DISK" -> Some(runSpec.resources.disk.toString),
-        "MARATHON_APP_RESOURCE_GPUS" -> Some(runSpec.resources.gpus.toString)
+        "MARATHON_APP_RESOURCE_GPUS" -> Some(runSpec.resources.gpus.toString),
+        "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH" -> Some(runSpec.resources.networkBandwidth.toString)
       ).collect {
           case (key, Some(value)) => key -> value
         }(collection.breakOut)

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -93,16 +93,19 @@ object TaskGroupBuilder extends StrictLogging {
     val mem = BigDecimal(pod.executorResources.mem) + pod.containers.map(c => BigDecimal(c.resources.mem)).sum
     val disk = BigDecimal(pod.executorResources.disk) + pod.containers.map(c => BigDecimal(c.resources.disk)).sum
     val gpus = BigDecimal(pod.executorResources.gpus) + pod.containers.map(c => BigDecimal(c.resources.gpus)).sum
+    val networkBandwidth = BigDecimal(pod.executorResources.networkBandwidth) + pod.containers.map(c => BigDecimal(c.resources.networkBandwidth)).sum
 
     val matchedCpus = matchedResources.filter(_.getName == "cpus").map(c => BigDecimal(c.getScalar.getValue)).sum
     val matchedMem = matchedResources.filter(_.getName == "mem").map(c => BigDecimal(c.getScalar.getValue)).sum
     val matchedDisk = matchedResources.filter(_.getName == "disk").map(c => BigDecimal(c.getScalar.getValue)).sum
     val matchedGpus = matchedResources.filter(_.getName == "gpus").map(c => BigDecimal(c.getScalar.getValue)).sum
+    val matchedNetworkBandwidth = matchedResources.filter(_.getName == "network_bandwidth").map(c => BigDecimal(c.getScalar.getValue)).sum
 
     assert(cpus <= matchedCpus)
     assert(mem <= matchedMem)
     assert(disk <= matchedDisk)
     assert(gpus <= matchedGpus)
+    assert(networkBandwidth <= matchedNetworkBandwidth)
   }
 
   // We have list of (BigDecimal, Resource) pairs in order to avoid using == and != operators with doubles.
@@ -110,13 +113,15 @@ object TaskGroupBuilder extends StrictLogging {
       cpus: List[(BigDecimal, mesos.Resource)],
       mem: List[(BigDecimal, mesos.Resource)],
       disk: List[(BigDecimal, mesos.Resource)],
-      gpus: List[(BigDecimal, mesos.Resource)])
+      gpus: List[(BigDecimal, mesos.Resource)],
+      network_bandwidth: List[(BigDecimal, mesos.Resource)])
 
   private class ResourceConsumer(initial: Resources) {
     private var cpus = initial.cpus
     private var mem = initial.mem
     private var disk = initial.disk
     private var gpus = initial.gpus
+    private var networkBandwidth = initial.networkBandwidth
 
     // Find a CPU resource for the given quantity if possible, and remove the resource from the resource list.
     def consumeCpus(quantity: Double): Option[mesos.Resource] = {
@@ -150,6 +155,15 @@ object TaskGroupBuilder extends StrictLogging {
       consume(gpus, BigDecimal(quantity)).map {
         case (leftResources, consumedResource) =>
           gpus = leftResources
+          consumedResource
+      }
+    }
+
+    // Find a Network Bandwidth resource for the given quantity if possible, and remove the resource from the resource list.
+    def consumeNetworkBandwidth(quantity: Double): Option[mesos.Resource] = {
+      consume(networkBandwidth, BigDecimal(quantity)).map {
+        case (leftResources, consumedResource) =>
+          networkBandwidth = leftResources
           consumedResource
       }
     }
@@ -189,18 +203,23 @@ object TaskGroupBuilder extends StrictLogging {
     val gpuQuantities = {
       BigDecimal(pod.executorResources.gpus) :: pod.containers.map(c => BigDecimal(c.resources.gpus)).toList
     }.filter(_ > decimalZero)
+    val networkBandwidthQuantities = {
+      BigDecimal(pod.executorResources.networkBandwidth) :: pod.containers.map(c => BigDecimal(c.resources.networkBandwidth)).toList
+    }.filter(_ > decimalZero)
 
     val cpuResources = matchedResources.filter(_.getName == "cpus").toList
     val memResources = matchedResources.filter(_.getName == "mem").toList
     val diskResources = matchedResources.filter(_.getName == "disk").toList
     val gpuResources = matchedResources.filter(_.getName == "gpus").toList
+    val networkBandwidthResources = matchedResources.filter(_.getName == "network_bandwidth").toList
 
     val packedCpus = binPackResources(cpuQuantities, cpuResources)
     val packedMem = binPackResources(memQuantities, memResources)
     val packedDisk = binPackResources(diskQuantities, diskResources)
     val packedGpus = binPackResources(gpuQuantities, gpuResources)
+    val packedNetworkBandwidth = binPackResources(networkBandwidthQuantities, networkBandwidthResources)
 
-    Resources(cpus = packedCpus, mem = packedMem, disk = packedDisk, gpus = packedGpus)
+    Resources(cpus = packedCpus, mem = packedMem, disk = packedDisk, gpus = packedGpus, networkBandwidth = packedNetworkBandwidth)
   }
 
   private[this] def binPackResources(
@@ -355,6 +374,7 @@ object TaskGroupBuilder extends StrictLogging {
     consumer.consumeMem(container.resources.mem).foreach(builder.addResources)
     consumer.consumeDisk(container.resources.disk).foreach(builder.addResources)
     consumer.consumeGpus(container.resources.gpus.toDouble).foreach(builder.addResources)
+    consumer.consumeNetworkBandwidth(container.resources.networkBandwidth.toDouble).foreach(builder.addResources)
 
     if (container.labels.nonEmpty)
       builder.setLabels(mesos.Labels.newBuilder.addAllLabels(container.labels.map {
@@ -411,6 +431,7 @@ object TaskGroupBuilder extends StrictLogging {
     consumer.consumeMem(podDefinition.executorResources.mem).foreach(executorInfo.addResources)
     consumer.consumeDisk(podDefinition.executorResources.disk).foreach(executorInfo.addResources)
     consumer.consumeGpus(podDefinition.executorResources.gpus.toDouble).foreach(executorInfo.addResources)
+    consumer.consumeNetworkBandwidth(podDefinition.executorResources.networkBandwidth.toDouble).foreach(executorInfo.addResources)
     executorInfo.addAllResources(portsMatch.resources.asJava)
 
     if (podDefinition.networks.nonEmpty || podDefinition.volumes.nonEmpty) {
@@ -661,7 +682,8 @@ object TaskGroupBuilder extends StrictLogging {
       "MARATHON_CONTAINER_RESOURCE_CPUS" -> Some(container.resources.cpus.toString),
       "MARATHON_CONTAINER_RESOURCE_MEM" -> Some(container.resources.mem.toString),
       "MARATHON_CONTAINER_RESOURCE_DISK" -> Some(container.resources.disk.toString),
-      "MARATHON_CONTAINER_RESOURCE_GPUS" -> Some(container.resources.gpus.toString)
+      "MARATHON_CONTAINER_RESOURCE_GPUS" -> Some(container.resources.gpus.toString),
+      "MARATHON_CONTAINER_RESOURCE_NETWORK_BANDWIDTH" -> Some(container.resources.networkBandwidth.toString)
     ).collect {
         case (key, Some(value)) => key -> value
       }

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -114,7 +114,7 @@ object TaskGroupBuilder extends StrictLogging {
       mem: List[(BigDecimal, mesos.Resource)],
       disk: List[(BigDecimal, mesos.Resource)],
       gpus: List[(BigDecimal, mesos.Resource)],
-      network_bandwidth: List[(BigDecimal, mesos.Resource)])
+      networkBandwidth: List[(BigDecimal, mesos.Resource)])
 
   private class ResourceConsumer(initial: Resources) {
     private var cpus = initial.cpus

--- a/src/main/scala/mesosphere/mesos/protos/Resource.scala
+++ b/src/main/scala/mesosphere/mesos/protos/Resource.scala
@@ -8,4 +8,5 @@ object Resource {
   final val DISK = "disk"
   final val PORTS = "ports"
   final val GPUS = "gpus"
+  final val NETWORK_BANDWIDTH = "network_bandwidth"
 }

--- a/src/main/scala/mesosphere/mesos/protos/ScalarResource.scala
+++ b/src/main/scala/mesosphere/mesos/protos/ScalarResource.scala
@@ -10,4 +10,5 @@ object ScalarResource {
   def memory(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.MEM, value, role)
   def disk(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.DISK, value, role)
   def gpus(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.GPUS, value, role)
+  def networkBandwidth(value: Double, role: String = "*"): ScalarResource = ScalarResource(Resource.NETWORK_BANDWIDTH, value, role)
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -79,7 +79,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       (jsonApp1 \ "processedOffersSummary" \ "processedOffersCount").as[Int] should be(3)
       (jsonApp1 \ "processedOffersSummary" \ "unusedOffersCount").as[Int] should be(1)
       (jsonApp1 \ "processedOffersSummary" \ "rejectSummaryLaunchAttempt" \ 4 \ "declined").as[Int] should be(3)
-      (jsonApp1 \ "processedOffersSummary" \ "rejectSummaryLaunchAttempt" \ 9 \ "declined").as[Int] should be(2)
+      (jsonApp1 \ "processedOffersSummary" \ "rejectSummaryLaunchAttempt" \ 10 \ "declined").as[Int] should be(2)
       val offer = (jsonApp1 \ "lastUnusedOffers").as[JsArray].value.head \ "offer"
       (offer \ "agentId").as[String] should be(noMatch.offer.getSlaveId.getValue)
       (offer \ "hostname").as[String] should be(noMatch.offer.getHostname)

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -872,7 +872,7 @@ class MesosHealthCheckTest extends UnitTest {
 
   def buildIfMatches(app: AppDefinition): Option[(MesosProtos.TaskInfo, NetworkInfo)] = {
     val offer = MarathonTestHelper.makeBasicOfferWithRole(
-      cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved).build
+      cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved).build
 
     val config = MarathonTestHelper.defaultConfig()
     val taskId = Task.Id.forRunSpec(app.id)

--- a/src/test/scala/mesosphere/marathon/raml/OfferConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/OfferConversionTest.scala
@@ -75,7 +75,7 @@ class OfferConversionTest extends UnitTest {
       raml.attributes should have size 0
       raml.hostname should be (offer.getHostname)
       raml.id should be (offer.getId.getValue)
-      raml.resources should have size 5
+      raml.resources should have size 6
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
@@ -69,6 +69,7 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("InsufficientDisk", 10, 33), // 33 - 10 = 23
         DeclinedOfferStep("InsufficientGpus", 0, 23),
         DeclinedOfferStep("InsufficientPorts", 0, 23),
+        DeclinedOfferStep("InsufficientNetworkBandwidth", 0, 23),
         DeclinedOfferStep("DeclinedScarceResources", 0, 23)
       )
       val lastOffersSummary: Seq[DeclinedOfferStep] = List(
@@ -81,6 +82,7 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("InsufficientDisk", 0, 0),
         DeclinedOfferStep("InsufficientGpus", 0, 0),
         DeclinedOfferStep("InsufficientPorts", 0, 0),
+        DeclinedOfferStep("InsufficientNetworkBandwidth", 0, 0),
         DeclinedOfferStep("DeclinedScarceResources", 0, 0)
       )
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -81,7 +81,7 @@ object MarathonTestHelper {
   val frameworkID: FrameworkID = FrameworkID("marathon")
   val frameworkId: FrameworkId = FrameworkId("").mergeFromProto(frameworkID)
 
-  def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0,
+  def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0, networkBandwidth: Double = 100000.0,
     beginPort: Int = 31000, endPort: Int = 32000, role: String = ResourceRole.Unreserved,
     reservation: Option[ReservationLabels] = None, gpus: Double = 0.0): Offer.Builder = {
 
@@ -105,6 +105,7 @@ object MarathonTestHelper {
     val gpuResource = heedReserved(ScalarResource(Resource.GPUS, gpus, role = role))
     val memResource = heedReserved(ScalarResource(Resource.MEM, mem, role = role))
     val diskResource = heedReserved(ScalarResource(Resource.DISK, disk, role = role))
+    val networkBandwidthResource = heedReserved(ScalarResource(Resource.NETWORK_BANDWIDTH, networkBandwidth, role = role))
     val portsResource = if (beginPort <= endPort) {
       Some(heedReserved(RangesResource(
         Resource.PORTS,
@@ -123,6 +124,7 @@ object MarathonTestHelper {
       .addResources(gpuResource)
       .addResources(memResource)
       .addResources(diskResource)
+      .addResources(networkBandwidthResource)
 
     portsResource.foreach(offerBuilder.addResources)
 
@@ -300,7 +302,7 @@ object MarathonTestHelper {
     offerBuilder
   }
 
-  def makeBasicOfferWithRole(cpus: Double, mem: Double, disk: Double,
+  def makeBasicOfferWithRole(cpus: Double, mem: Double, disk: Double, networkBandwidth: Double,
     beginPort: Int, endPort: Int, role: String) = {
     val portsResource = RangesResource(
       Resource.PORTS,
@@ -310,6 +312,7 @@ object MarathonTestHelper {
     val cpusResource = ScalarResource(Resource.CPUS, cpus, role)
     val memResource = ScalarResource(Resource.MEM, mem, role)
     val diskResource = ScalarResource(Resource.DISK, disk, role)
+    val networkBandwidthResource = ScalarResource(Resource.NETWORK_BANDWIDTH, networkBandwidth, role)
     Offer.newBuilder
       .setId(OfferID("1"))
       .setFrameworkId(frameworkID)

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -75,7 +75,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         portDefinitions = PortDefinitions(0, 0)
       )
 
-      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
       val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -453,7 +453,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         portDefinitions = PortDefinitions(0, 0)
       )
 
-      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -6,15 +6,15 @@ import java.util.UUID
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{App, Resources}
-import mesosphere.marathon.state.Container.{Docker, PortMapping}
+import mesosphere.marathon.raml.{ App, Resources }
+import mesosphere.marathon.state.Container.{ Docker, PortMapping }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
+import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
 import mesosphere.marathon.{Protos, _}
@@ -35,14 +35,14 @@ class TaskBuilderTest extends UnitTest {
 
   "TaskBuilder" should {
     "BuildIfMatches" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.0, mem = 128.0, disk = 2000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000).build
 
       val task: Option[(MesosProtos.TaskInfo, NetworkInfo)] = buildIfMatches(
         offer,
         AppDefinition(
           id = "/product/frontend".toPath,
           cmd = Some("foo"),
-          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
+          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0, networkBandwidth = 100),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         )
@@ -322,14 +322,14 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "build creates task with appropriate resource share" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 2.0, mem = 128.0, disk = 2000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000).build
 
       val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
         offer,
         AppDefinition(
           id = "/product/frontend".toPath,
           cmd = Some("foo"),
-          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
+          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0, networkBandwidth = 100),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         )
@@ -342,6 +342,7 @@ class TaskBuilderTest extends UnitTest {
       assert(resource("cpus") == ScalarResource("cpus", 1))
       assert(resource("mem") == ScalarResource("mem", 64))
       assert(resource("disk") == ScalarResource("disk", 1))
+      assert(resource("network_bandwidth") == ScalarResource("network_bandwidth", 100))
       val portsResource: Resource = resource("ports")
       assert(portsResource.getRanges.getRangeList.map(range => range.getEnd - range.getBegin + 1).sum == 2)
       assert(portsResource.getRole == ResourceRole.Unreserved)
@@ -369,7 +370,7 @@ class TaskBuilderTest extends UnitTest {
 
     "build creates task with appropriate resource share also preserves role" in {
       val offer = MarathonTestHelper.makeBasicOffer(
-        cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000, role = "marathon"
+        cpus = 2.0, mem = 128.0, disk = 2000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon"
       ).build
 
       val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
@@ -377,7 +378,7 @@ class TaskBuilderTest extends UnitTest {
         AppDefinition(
           id = "/product/frontend".toPath,
           cmd = Some("foo"),
-          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
+          resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0, networkBandwidth = 100),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         ),
@@ -392,6 +393,7 @@ class TaskBuilderTest extends UnitTest {
       assert(resource("cpus") == ScalarResource("cpus", 1, "marathon"))
       assert(resource("mem") == ScalarResource("mem", 64, "marathon"))
       assert(resource("disk") == ScalarResource("disk", 1, "marathon"))
+      assert(resource("network_bandwidth") == ScalarResource("network_bandwidth", 100, "marathon"))
       val portsResource: Resource = resource("ports")
       assert(portsResource.getRanges.getRangeList.map(range => range.getEnd - range.getBegin + 1).sum == 2)
       assert(portsResource.getRole == "marathon")
@@ -620,7 +622,7 @@ class TaskBuilderTest extends UnitTest {
 
     "build creates task for MESOS Docker container" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -662,7 +664,7 @@ class TaskBuilderTest extends UnitTest {
 
     "build creates task for MESOS AppC container" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1016,13 +1018,15 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "BuildIfMatchesWithRole" in {
-      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon")
+      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon")
         .addResources(ScalarResource("cpus", 1, ResourceRole.Unreserved))
         .addResources(ScalarResource("mem", 128, ResourceRole.Unreserved))
         .addResources(ScalarResource("disk", 1000, ResourceRole.Unreserved))
+        .addResources(ScalarResource("network_bandwidth", 400, ResourceRole.Unreserved))
         .addResources(ScalarResource("cpus", 2, "marathon"))
         .addResources(ScalarResource("mem", 256, "marathon"))
         .addResources(ScalarResource("disk", 2000, "marathon"))
+        .addResources(ScalarResource("network_bandwidth", 600, "marathon"))
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
 
@@ -1030,7 +1034,7 @@ class TaskBuilderTest extends UnitTest {
         offer,
         AppDefinition(
           id = "/testApp".toPath,
-          resources = Resources(cpus = 2.0, mem = 200.0, disk = 2.0),
+          resources = Resources(cpus = 2.0, mem = 200.0, disk = 2.0, networkBandwidth = 600),
           executor = "//cmd",
           portDefinitions = PortDefinitions(8080, 8081)
         ),
@@ -1055,13 +1059,15 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "BuildIfMatchesWithRole2" in {
-      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved)
+      val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved)
         .addResources(ScalarResource("cpus", 1, ResourceRole.Unreserved))
         .addResources(ScalarResource("mem", 128, ResourceRole.Unreserved))
         .addResources(ScalarResource("disk", 1000, ResourceRole.Unreserved))
+        .addResources(ScalarResource("network_bandwidth", 400, ResourceRole.Unreserved))
         .addResources(ScalarResource("cpus", 2, "marathon"))
         .addResources(ScalarResource("mem", 256, "marathon"))
         .addResources(ScalarResource("disk", 2000, "marathon"))
+        .addResources(ScalarResource("network_bandwidth", 600))
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
 
@@ -1094,7 +1100,7 @@ class TaskBuilderTest extends UnitTest {
 
     "PortMappingsWithZeroContainerPort" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31000, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31000, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1122,7 +1128,7 @@ class TaskBuilderTest extends UnitTest {
 
     "PortMappingsWithUserModeAndDefaultPortMapping" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1154,7 +1160,7 @@ class TaskBuilderTest extends UnitTest {
 
     "Docker Container PortMappingsWithoutHostPort" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1189,7 +1195,7 @@ class TaskBuilderTest extends UnitTest {
 
     "Mesos Container PortMappingsWithoutHostPort" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1228,7 +1234,7 @@ class TaskBuilderTest extends UnitTest {
 
     "DockerContainerWithMesosTaskIdLabel" in {
       val offer = MarathonTestHelper.makeBasicOfferWithRole(
-        cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
+        cpus = 1.0, mem = 128.0, disk = 1000.0, networkBandwidth = 1000.0, beginPort = 31000, endPort = 31010, role = ResourceRole.Unreserved
       )
         .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
         .build
@@ -1432,6 +1438,7 @@ class TaskBuilderTest extends UnitTest {
           "MARATHON_APP_RESOURCE_MEM" -> App.DefaultMem.toString,
           "MARATHON_APP_RESOURCE_DISK" -> App.DefaultDisk.toString,
           "MARATHON_APP_RESOURCE_GPUS" -> App.DefaultGpus.toString,
+          "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH" -> App.DefaultNetworkBandwidth.toString,
           "MARATHON_APP_LABELS" -> ""
         )
       )
@@ -1446,7 +1453,7 @@ class TaskBuilderTest extends UnitTest {
         container = Some(Docker(
           image = "myregistry/myimage:version"
         )),
-        resources = Resources(cpus = 10.0, mem = 256.0, disk = 128.0, gpus = 2),
+        resources = Resources(cpus = 10.0, mem = 256.0, disk = 128.0, gpus = 2, networkBandwidth = 1024),
         labels = Map(
           "LABEL1" -> "VALUE1",
           "LABEL2" -> "VALUE2"
@@ -1465,6 +1472,7 @@ class TaskBuilderTest extends UnitTest {
           "MARATHON_APP_RESOURCE_MEM" -> "256.0",
           "MARATHON_APP_RESOURCE_DISK" -> "128.0",
           "MARATHON_APP_RESOURCE_GPUS" -> "2",
+          "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH" -> "1024",
           "MARATHON_APP_LABELS" -> "LABEL1 LABEL2",
           "MARATHON_APP_LABEL_LABEL1" -> "VALUE1",
           "MARATHON_APP_LABEL_LABEL2" -> "VALUE2"
@@ -1634,7 +1642,7 @@ class TaskBuilderTest extends UnitTest {
       val nonPrefixedEnvVars = env.filterKeys(!_.startsWith("P_"))
 
       val whiteList = Seq("MESOS_TASK_ID", "MARATHON_APP_ID", "MARATHON_APP_VERSION", "MARATHON_APP_RESOURCE_CPUS",
-        "MARATHON_APP_RESOURCE_MEM", "MARATHON_APP_RESOURCE_DISK", "MARATHON_APP_RESOURCE_GPUS", "MARATHON_APP_LABELS")
+        "MARATHON_APP_RESOURCE_MEM", "MARATHON_APP_RESOURCE_DISK", "MARATHON_APP_RESOURCE_GPUS", "MARATHON_APP_LABELS", "MARATHON_APP_RESOURCE_NETWORK_BANDWIDTH")
 
       assert(nonPrefixedEnvVars.keySet.forall(whiteList.contains))
     }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -6,15 +6,15 @@ import java.util.UUID
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
-import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{ App, Resources }
-import mesosphere.marathon.state.Container.{ Docker, PortMapping }
+import mesosphere.marathon.raml.{App, Resources}
+import mesosphere.marathon.state.Container.{Docker, PortMapping}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
+import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
 import mesosphere.marathon.{Protos, _}

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -64,7 +64,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
     }
 
     "build from a PodDefinition with a single container" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0, disk = 10.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0, disk = 10.0, networkBandwidth = 100.0).build
 
       val podSpec = PodDefinition(
         id = "/product/frontend".toPath,
@@ -72,7 +72,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
           MesosContainer(
             name = "Foo",
             exec = None,
-            resources = raml.Resources(cpus = 1.0f, mem = 128.0f)
+            resources = raml.Resources(cpus = 1.0f, mem = 128.0f, networkBandwidth = 100)
           )
         )
       )
@@ -95,22 +95,22 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
     }
 
     "build from a PodDefinition with multiple containers" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0, networkBandwidth = 400.0).build
 
       val podSpec = PodDefinition(
         id = "/product/frontend".toPath,
         containers = Seq(
           MesosContainer(
             name = "Foo",
-            resources = raml.Resources(cpus = 1.0f, mem = 512.0f)
+            resources = raml.Resources(cpus = 1.0f, mem = 512.0f, networkBandwidth = 100)
           ),
           MesosContainer(
             name = "Foo2",
-            resources = raml.Resources(cpus = 2.0f, mem = 256.0f)
+            resources = raml.Resources(cpus = 2.0f, mem = 256.0f, networkBandwidth = 100)
           ),
           MesosContainer(
             name = "Foo3",
-            resources = raml.Resources(cpus = 1.0f, mem = 256.0f)
+            resources = raml.Resources(cpus = 1.0f, mem = 256.0f, networkBandwidth = 100)
           )
         )
       )
@@ -378,7 +378,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.0f, mem = 1024.0f, disk = 10.0).build()
       val mesosContainer = MesosContainer(
         name = containerIdStr,
-        resources = raml.Resources(cpus = 2.0f, mem = 512.0f, disk = 0.0f)
+        resources = raml.Resources(cpus = 2.0f, mem = 512.0f, disk = 0.0f, networkBandwidth = 100)
       )
 
       val podSpec = PodDefinition(


### PR DESCRIPTION
This pull request updates the version of Marathon to 1.6.549 (latest stable) and applies our patches for network bandwidth control. The health check patch is already included upstream. The criteo/1.6.549 is a branch forked from the upstream commit aabf74302 which is recommended to be used in production because it was tested and verified.

Some of the code had to be slightly refactored to resolve merge conflicts and comply with the different code structure and implementation.