### PR TITLE
Remove useless multi-line log

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -166,7 +166,8 @@ private[launcher] class OfferProcessorImpl(
 
     def saveTask(taskOpWithSource: InstanceOpWithSource): Future[Option[InstanceOpWithSource]] = {
       val taskId = taskOpWithSource.instanceId
-      logger.info(s"Processing ${taskOpWithSource.op.stateOp} for ${taskOpWithSource.instanceId}")
+      logger.info(s"Processing <long object redacted> for ${taskOpWithSource.instanceId}")
+      logger.debug(s"Processing ${taskOpWithSource.op.stateOp} for ${taskOpWithSource.instanceId}")
       instanceTracker
         .process(taskOpWithSource.op.stateOp)
         .map(_ => Some(taskOpWithSource))


### PR DESCRIPTION
There is on reason to dump complex (and multiline) objects at info
level. It makes logs very hard to read and does not cope well with
anything that don't detect multilen properly.

Change-Id: I9716d15d7d2fe66cff07214685a2ae337c31b2c2