### PR TITLE
Fix ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 
 # any change to this file upstream will conflict when we merge changes
 # deploy section has to remain intact but the rest can be resolved using upstream version
+dist: trusty
 sudo: false
 language: scala
 jdk:


### PR DESCRIPTION
We need to build explicitely on Ubuntu Trusty, at least as long as we
are using jdk8.
https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476
https://travis-ci.community/t/install-of-oracle-jdk-8-failing