### PR TITLE
Anti snowball round 4: let's make it opt-in (somehow)

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -143,7 +143,7 @@ private[health] class HealthCheckActor(
       if (instance.isUnreachable) {
         logger.info(s"Instance $instanceId on host ${instance.agentInfo.host} is temporarily unreachable. Performing no kill.")
       } else {
-        if (!(checkEnoughInstancesRunning())) {
+        if (antiSnowballEnabled && !(checkEnoughInstancesRunning())) {
           logger.info(s"[anti-snowball] Won't kill $instanceId because too few instances are running")
           return
         }
@@ -167,6 +167,10 @@ private[health] class HealthCheckActor(
         killService.killInstancesAndForget(Seq(instance), KillReason.FailedHealthChecks)
       }
     }
+  }
+
+  def antiSnowballEnabled(): Boolean = {
+    app.upgradeStrategy.minimumHealthCapacity < 1
   }
 
   /** Check if enough active and ready instances will remain if we kill 1 unhealthy instance */

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -24,7 +24,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
 
     val appId = "/test".toPath
     val appVersion = Timestamp(1)
-    val app = AppDefinition(id = appId, instances = 10, upgradeStrategy = UpgradeStrategy(0.9, 1.1))
+    val app = AppDefinition(id = appId, instances = 10, upgradeStrategy = UpgradeStrategy(0.9, 0.1))
     val appWithoutAntiSnowball = AppDefinition(id = appId, instances = 10)
     val appRepository: AppRepository = mock[AppRepository]
     val holder: MarathonSchedulerDriverHolder = new MarathonSchedulerDriverHolder


### PR DESCRIPTION
For small pool or apps which care more about being scheduled quickly than maintaining a zombie-pool alive, we need to make the feature somehow opt-in.
The chosen approach is to activate anti-snowball feature only for apps setting explicitly `upgradeStrategy.minimumHealthCapacity` to non-default value (so < 1).
Rationals are:
* for (most) apps which don't set or care about deployment strategy, there is probably no reason to prevent their unhealthy instances from being killed (allowing those apps to go as down as 0 instances ) and quickly rescheduled
* apps settings a minimumHealthCapacity below 1 would probably like the contract to be maintain not only during rollouts / deployments but also at runtime when instances are failing
* last but not least, of all implementation options this was the simplest one (so less regression risk)