### PR TITLE
Use upstream version as version to avoid meaningless versionning in Maratho…

### DIFF
--- a/version
+++ b/version
@@ -8,7 +8,7 @@ MAJOR=1
 MINOR=9
 BRANCH_POINT=8228cea
 PREVIOUS_BRANCH=origin/releases/1.$(($MINOR - 1))
-REF=HEAD
+REF=b9c86683866
 
 declare -a OTHERARGS
 help() {


### PR DESCRIPTION
…n-UI

I'm still checking if there is no side effect, but basically this is to avoid printing wrong version in marathon-ui info modal.

For example, our 1.9.109-rc1 was shown as 1.9.339, and our 1.9.109-rc3 is currently shown as 1.9.133, which is lower
