### PR TITLE
Decrease verbosity of some logs

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -181,7 +181,7 @@ class MarathonHealthCheckManager(
 
     def reconcileApp(app: AppDefinition, instances: Seq[Instance]): Future[Done] = {
       val appId = app.id
-      logger.info(s"reconcile $appId with latest version ${app.version} for instances: $instances")
+      logger.info(s"reconcile $appId with latest version ${app.version} for ${instances.length} instances")
 
       val instancesByVersion = instances.groupBy(_.runSpecVersion)
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -263,8 +263,7 @@ private class TaskLauncherActor(
           offerOperationAcceptTimeout.get(instanceId).foreach(_.cancel())
           offerOperationAcceptTimeout -= instanceId
         }
-
-        logger.info(s"Synced single $instanceId from InstanceTracker: ${instance.runSpec.id}")
+        logger.info(s"Synced single $instanceId from InstanceTracker")
 
         // Request delay for new run spec config.
         if (!launchAllowedAt.contains(instance.runSpec.configRef)) {

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -263,7 +263,8 @@ private class TaskLauncherActor(
           offerOperationAcceptTimeout.get(instanceId).foreach(_.cancel())
           offerOperationAcceptTimeout -= instanceId
         }
-        logger.info(s"Synced single $instanceId from InstanceTracker")
+
+        logger.info(s"Synced single $instanceId from InstanceTracker: ${instance.runSpec.id}")
 
         // Request delay for new run spec config.
         if (!launchAllowedAt.contains(instance.runSpec.configRef)) {

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -78,7 +78,7 @@ case class Task(taskId: Task.Id, runSpecVersion: Timestamp, status: Task.Status)
     // state should already be distinct enough.
     // related to https://github.com/mesosphere/marathon/pull/4531
     if (this.isTerminal) {
-      logger.warn(s"received update($newStatus, $newMesosStatus, $now) for terminal $taskId, ignoring")
+      logger.debug(s"received update($newStatus, $newMesosStatus, $now) for terminal $taskId, ignoring")
       return TaskUpdateEffect.Noop
     }
 


### PR DESCRIPTION
Logs that are multiline usually decrease readability. We make them a bit
more readable (removing extra info or changing their priority)

Change-Id: Ia85eaa31e72f9ae9fb2ef453a0a5e623e9820771