### PR TITLE
Avoid killing instances upon scale down when it is unnecessary

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -78,6 +78,9 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
     containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskStaged(containerName, stagedAt, version).build()
 
+  def addTaskScheduled(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
+    addTaskWithBuilder().taskScheduled(since, containerName).build()
+
   def addTaskWithBuilder(): TestTaskBuilder = TestTaskBuilder.newBuilder(this)
 
   private[instance] def addTask(task: Task): TestInstanceBuilder = {

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -111,6 +111,7 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
 
   def mesosStatusForCondition(condition: Condition, taskId: Task.Id): Option[mesos.Protos.TaskStatus] =
     condition match {
+      case Condition.Scheduled => None
       case Condition.Provisioned => None
       case Condition.Dropped => Some(MesosTaskStatusTestHelper.dropped(taskId))
       case Condition.Error => Some(MesosTaskStatusTestHelper.error(taskId))
@@ -179,6 +180,9 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
     this.copy(task = Some(TestTaskBuilder.Helper.startingTaskForApp(
       instance.instanceId, stagedAt = stagedAt.millis, container = maybeMesosContainerByName(containerName))))
   }
+
+  def taskScheduled(since: Timestamp = now, containerName: Option[String] = None): TestTaskBuilder =
+    createTask(since, containerName, Condition.Scheduled)
 
   private def createTask(since: Timestamp, containerName: Option[String], condition: Condition) = {
     val instance = instanceBuilder.getInstance()


### PR DESCRIPTION
Example of issue that is fixed with this patch:
- context: an app has 100 green instances and 50 unscheduled ones
- trigger: the app is scaled down to 100 instances
- issue: Marathon deletes 50 green instances instead of the unscheduled ones

JIRA: MESOS-4489