### PR TITLE
Let HealthCheckActor forget outdated healthcheck result

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -57,25 +57,17 @@ class TaskReplaceActor(
   def isHealthy(instance: Instance, healths: Map[Instance.Id, Seq[Health]]): Boolean = {
     val i_health = healths.find(_._1 == instance.instanceId)
     if (instance.hasConfiguredHealthChecks && i_health.isDefined)
-      return _isHealthy(instance, i_health.get._2)
+      return _isHealthy(i_health.get._2)
     else if (instance.hasConfiguredHealthChecks && !i_health.isDefined)
       return false
     else
       return instance.isRunning
   }
 
-  def _isHealthy(instance: Instance, healths: Seq[Health]): Boolean = {
+  def _isHealthy(healths: Seq[Health]): Boolean = {
     for (h <- healths)
-      if (!h.alive && !isOutdatedHealth(instance, h)) return false // this is a workaround until MESOS-4592 is fixed
+      if (!h.alive) return false
     return true
-  }
-
-  // A healthcheck status is outdated if the last success / failure timestamp
-  // is prior to the timestamp at which the task was staged at
-  def isOutdatedHealth(instance: Instance, health: Health): Boolean = {
-    val taskStagedAt = instance.appTask.status.stagedAt
-    return (health.lastSuccess.isDefined && health.lastSuccess.get.before(taskStagedAt)) ||
-      (health.lastFailure.isDefined && health.lastFailure.get.before(taskStagedAt))
   }
 
   def request_health_status(): Unit = {


### PR DESCRIPTION
We observed an issue with Mesos healthchecks.
When a task failed its Mesos HC, it was killed and replaced by a new
task - this was expected. What was unexpected however was that the new
task was also seen as unhealthy (even if it was running correctly), with
2 healthcheck results attached to it (an outdated one reporting a
failure, and a correct one reporting success).
    
This commit fixes the issue by letting the HealthCheckActor forget
outdated healthckeck result.
    
JIRA: MESOS-4437