### PR TITLE
Anti-snowball does not manage to recycle unhealthy apps

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
@@ -5,7 +5,7 @@ import akka.actor.{Actor, Props}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.InstanceHealthChanged
-import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{AddHealthCheck, AppHealthCheckProxy, ApplicationKey, HealthCheckStatusChanged, PurgeHealthCheckStatuses, RemoveHealthCheck}
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{AddHealthCheck, AppHealthCheckProxy, ApplicationKey, HealthCheckStatesRequest, HealthCheckStatesResponse, HealthCheckStatusChanged, PurgeHealthCheckStatuses, RemoveHealthCheck}
 import mesosphere.marathon.core.health.{Health, HealthCheck}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{AbsolutePathId, Timestamp}

--- a/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
@@ -31,7 +31,7 @@ object AppHealthCheckActor {
 
   case class HealthCheckStatesRequest(appId: AbsolutePathId)
 
-  case class HealthCheckStatesResponse(res: mutable.Map[InstanceKey, Map[HealthCheck, Option[Health]]])
+  case class HealthCheckStatesResponse(res: Map[InstanceKey, Map[HealthCheck, Option[Health]]])
 
   /**
     * Actor command adding an health check definition for a given application so that the actor knows which health check
@@ -87,8 +87,8 @@ object AppHealthCheckActor {
     private[impl] val healthCheckStates: mutable.Map[InstanceKey, Map[HealthCheck, Option[Health]]] =
       mutable.Map.empty
 
-    def getHealthCheckStates(appId: AbsolutePathId): mutable.Map[InstanceKey, Map[HealthCheck, Option[Health]]] = {
-      healthCheckStates.filterKeys(instanceKey => instanceKey.applicationKey.appId == appId)
+    def getHealthCheckStates(appId: AbsolutePathId): Map[InstanceKey, Map[HealthCheck, Option[Health]]] = {
+      healthCheckStates.filterKeys(instanceKey => instanceKey.applicationKey.appId == appId).toMap
     }
 
     /**


### PR DESCRIPTION
Anti-snowball is implemented inside the HealthCheckActor. A HealthCheckActor keeps track of health check results for a given version of a given app. Since several versions of an app can run concurrently, sometimes the HealthCheckActor cannot take the right decision because it has only a partial view of the application.
This patch allows the HealthCheckActor to have a global view of the application healthiness by communicating with the AppHealthCheckActor, when it is needed.

JIRA: MESOS-4551