### PR TITLE
wrapping Unprocessed offer queue insertion function 

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
@@ -49,7 +49,7 @@ trait OfferMatcherManagerConfig extends ScallopConf {
     default = Some(1024),
     hidden = true
   )
-  
+
   /**
     * This parameter controlls the order of processing for offers present in the offers queue
     * by setting this parameter to true, the unprocessed offers will be processed in FIFO order.

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
@@ -49,4 +49,18 @@ trait OfferMatcherManagerConfig extends ScallopConf {
     default = Some(1024),
     hidden = true
   )
+  
+  /**
+    * This parameter controlls the order of processing for offers present in the offers queue
+    * by setting this parameter to true, the unprocessed offers will be processed in FIFO order.
+    * The default behavior is LIFO.
+    */
+  lazy val queuedOffersFifo = toggle(
+    "queued_offers_fifo",
+    descrYes = "(Default) Marathon Offer Queue will work in FIFO",
+    descrNo = "(Default) Marathon Offer Que ue will work in default behavior which is LIFO",
+    prefix = "desactivate_",
+    noshort = true,
+    default = Some(false))
+
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
@@ -51,14 +51,14 @@ trait OfferMatcherManagerConfig extends ScallopConf {
   )
 
   /**
-    * This parameter controlls the order of processing for offers present in the offers queue
+    * This parameter controls the order of processing for offers present in the offers queue
     * by setting this parameter to true, the unprocessed offers will be processed in FIFO order.
     * The default behavior is LIFO.
     */
   lazy val queuedOffersFifo = toggle(
     "queued_offers_fifo",
     descrYes = "(Default) Marathon Offer Queue will work in FIFO",
-    descrNo = "(Default) Marathon Offer Que ue will work in default behavior which is LIFO",
+    descrNo = "(Default) Marathon Offer Queue will work in default behavior which is LIFO",
     prefix = "desactivate_",
     noshort = true,
     default = Some(false))

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
@@ -53,14 +53,14 @@ trait OfferMatcherManagerConfig extends ScallopConf {
   /**
     * This parameter controls the order of processing for offers present in the offers queue
     * by setting this parameter to true, the unprocessed offers will be processed in FIFO order.
-    * The default behavior is LIFO.
+    * The default behavior is FIFO.
     */
   lazy val queuedOffersFifo = toggle(
     "queued_offers_fifo",
     descrYes = "(Default) Marathon Offer Queue will work in FIFO",
     descrNo = "(Default) Marathon Offer Queue will work in default behavior which is LIFO",
-    prefix = "desactivate_",
+    prefix = "deactivate_",
     noshort = true,
-    default = Some(false))
+    default = Some(true))
 
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -117,9 +117,9 @@ private[impl] class OfferMatcherManagerActor private (
     val timeout = conf.offerMatchingTimeout()
     timerTick = Some(context.system.scheduler.schedule(timeout, timeout, self, CleanUpOverdueOffers))
     // choose the strategy of insertion at initialization for the unprocessed offers queue
-    if (conf.queuedOffersFifo.toOption.get == true) {
+    if (conf.queuedOffersFifo.toOption.get) {
       addToUnprocessedOffers = {
-        logger.info(s"Unrpocessed Offers FIFO Mode is activated")
+        logger.info(s"Unprocessed Offers FIFO Mode is activated")
         (offersQueue: List[UnprocessedOffer], unprocessedOffer: UnprocessedOffer) => offersQueue :+ unprocessedOffer
       }
     }
@@ -199,9 +199,7 @@ private[impl] class OfferMatcherManagerActor private (
       if (offerQueues.size < conf.maxParallelOffers()) {
         startProcessOffer(offer, deadline, promise)
       } else if (unprocessedOffers.size < conf.maxQueuedOffers()) {
-       logger.debug(s"The maximum number of configured offers is processed at the moment. Queue offer ${offer.getId.getValue}.")
-        // Old code 
-        // unprocessedOffers ::= UnprocessedOffer(offer, deadline, promise)
+        logger.debug(s"The maximum number of configured offers is processed at the moment. Queue offer ${offer.getId.getValue}.")
         unprocessedOffers = addToUnprocessedOffers(unprocessedOffers, UnprocessedOffer(offer, deadline, promise));
 
       } else {


### PR DESCRIPTION
This is a fix of OfferMatcher Module to preserve offers processing order as sent by MESOS.
These fix is a part of reducing Mesos resources Fragmentation. #see [Confluence Page](https://confluence.criteois.com/display/~d.dahmane/Mesos+Fragmentation+Internship) for more informations.
a new flag is added to chose insertion order on unprocessed offers in OfferMatcher( FIFO, LIFO).
