### PR TITLE
Added Request Resources directive 

### DIFF
--- a/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStateTest.scala
+++ b/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStateTest.scala
@@ -36,7 +36,7 @@ class ReviveOffersStateTest extends UnitTest with Inside {
       .withSnapshot(InstancesSnapshot(List(monitoringScheduledInstance)), defaultRole = "*")
 
     val priorVersion = inside(state.roleReviveVersions("monitoring")) {
-      case VersionedRoleState(version, roleState) =>
+      case VersionedRoleState(version, roleState, _) =>
         roleState shouldBe OffersWanted
         version
     }
@@ -48,7 +48,7 @@ class ReviveOffersStateTest extends UnitTest with Inside {
     state = state.withoutDelay(monitoringApp.configRef)
 
     inside(state.roleReviveVersions("monitoring")) {
-      case VersionedRoleState(version, roleState) =>
+      case VersionedRoleState(version, roleState, _) =>
         roleState shouldBe OffersWanted
         version should be > priorVersion
     }


### PR DESCRIPTION
Added a role directive "Request Resources" to update minimum resources requested by each role.
the new directive is translated into a Request Resources Call sent to Mesos.
This directive is triggered every time a change occurs on the instances to deploy list, and take in consideration only the scheduled instances by filtering on the backed off instances. 